### PR TITLE
Add a force_login method to SeleniumWrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -276,12 +276,14 @@ of Django's test client. It has all `selenium driver attributes and
 methods`_, but you will mostly use ``get()``. It also has the
 following additional methods:
 
-* ``self.selenium.login(**credentials)``, ``self.selenium.logout()``
+* ``self.selenium.login(**credentials)``,
+``self.selenium.force_login(user, backend=None)``,
+``self.selenium.logout()``
 
-  Similar to the Django test client ``login()`` and ``logout()``
-  methods.  ``login()`` returns ``True`` if login is possible;
-  ``False`` if the provided credentials are incorrect, or the user is
-  inactive, or if the sessions framework is not available.
+  Similar to the Django test client ``login()``, `force_login()`` and
+  ``logout()`` methods.  ``login()`` returns ``True`` if login is
+  possible; ``False`` if the provided credentials are incorrect, or the
+  user is inactive, or if the sessions framework is not available.
 
 * ``self.selenium.wait_until_n_windows(n, timeout=2)``
 

--- a/django_selenium_clean/__init__.py
+++ b/django_selenium_clean/__init__.py
@@ -56,25 +56,54 @@ class SeleniumWrapper(object):
 
         The code is based on django.test.client.Client.login.
         """
-        from django.contrib.auth import authenticate, login
-
-        # Visit the home page to ensure the cookie gets the proper domain
-        self.get(self.live_server_url)
+        from django.contrib.auth import authenticate
 
         user = authenticate(**credentials)
-        if not (
+        if (
             user
             and user.is_active
             and "django.contrib.sessions" in settings.INSTALLED_APPS
         ):
+            self._login(user)
+            return True
+        else:
             return False
+
+    def force_login(self, user, backend=None):
+        """
+        Sets selenium to appear as if a user has successfully signed in.
+
+        The user will have its backend attribute set to the value of the
+        backend argument (which should be a dotted Python path string),
+        or to settings.AUTHENTICATION_BACKENDS[0] if a value isn't
+        provided. The authenticate() function called by login() normally
+        annotates the user like this.
+
+        The code is based on django.test.client.Client.force_login.
+        """
+
+        def get_backend():
+            from django.contrib.auth import load_backend
+
+            for backend_path in settings.AUTHENTICATION_BACKENDS:
+                backend = load_backend(backend_path)
+                if hasattr(backend, "get_user"):
+                    return backend_path
+
+        if backend is None:
+            backend = get_backend()
+        user.backend = backend
+        self._login(user, backend)
+
+    def _login(self, user, backend=None):
+        from django.contrib.auth import login
 
         engine = import_module(settings.SESSION_ENGINE)
 
         # Create a fake request to store login details.
         request = HttpRequest()
         request.session = engine.SessionStore()
-        login(request, user)
+        login(request, user, backend)
 
         # Save the session values.
         request.session.save()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -50,7 +50,7 @@ class DjangoSeleniumCleanTestCase(SeleniumTestCase):
         if cap["browserName"] == "phantomjs" and cap["version"] == "2.1.1":
             raise SkipTest("https://github.com/ariya/phantomjs/issues/14228")
 
-        User.objects.create(
+        alice = User.objects.create(
             username="alice", password=make_password("topsecret"), is_active=True
         )
 
@@ -62,6 +62,23 @@ class DjangoSeleniumCleanTestCase(SeleniumTestCase):
         # Log on
         r = self.selenium.login(username="alice", password="topsecret")
         self.assertTrue(r)
+
+        # Verify we are logged on
+        self.selenium.get(self.live_server_url)
+        self.user_info.wait_until_is_displayed()
+        self.assertEqual(self.user_info.text, "The logged on user is alice.")
+
+        # Log out
+        self.selenium.logout()
+
+        # Verify we are logged out
+        self.selenium.get(self.live_server_url)
+        self.user_info.wait_until_is_displayed()
+        self.assertEqual(self.user_info.text, "No user is logged on.")
+
+        # Log on
+        r = self.selenium.force_login(alice)
+        self.assertIsNone(r)
 
         # Verify we are logged on
         self.selenium.get(self.live_server_url)


### PR DESCRIPTION
This PR adds a new force_login method to the SeleniumWrapper class. This method is analogous to the Django test client method [force_login added in Django 1.9](https://docs.djangoproject.com/en/1.9/releases/1.9/#tests).

Unlike `.login()`, the `.force_login()` method skips authentication and verification steps and directly sets the user to appear as logged in. In particular, this allows inactive users to login.

The code for the `login()` and new `force_login()` method now both use a private method _login(). This is analogous to the appropriate django source code.